### PR TITLE
team01 iceCreamShop frontend moved into team03

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -50,17 +50,17 @@ function App() {
           )
         }
         {
-          hasRole(currentUser, "ROLE_USER") && (
-            <>
-              <Route exact path="/ucsbdates/list" element={<IceCreamShopIndexPage />} />
-            </>
-          )
-        }
-        {
           hasRole(currentUser, "ROLE_ADMIN") && (
             <>
               <Route exact path="/ucsbdates/edit/:id" element={<UCSBDatesEditPage />} />
               <Route exact path="/ucsbdates/create" element={<UCSBDatesCreatePage />} />
+            </>
+          )
+        }
+        {
+          hasRole(currentUser, "ROLE_USER") && (
+            <>
+              <Route exact path="/icecreamshops/list" element={<IceCreamShopIndexPage />} />
             </>
           )
         }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -11,6 +11,10 @@ import UCSBDatesIndexPage from "main/pages/UCSBDates/UCSBDatesIndexPage";
 import UCSBDatesCreatePage from "main/pages/UCSBDates/UCSBDatesCreatePage";
 import UCSBDatesEditPage from "main/pages/UCSBDates/UCSBDatesEditPage";
 
+import IceCreamShopCreatePage from "main/pages/IceCreamShops/IceCreamShopCreatePage";
+import IceCreamShopEditPage from "main/pages/IceCreamShops/IceCreamShopEditPage";
+import IceCreamShopIndexPage from "main/pages/IceCreamShops/IceCreamShopIndexPage";
+import IceCreamShopDetailsPage from "main/pages/IceCreamShops/IceCreamShopDetailsPage";
 
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 
@@ -38,11 +42,17 @@ function App() {
             </>
           )
         }
-
         {
           hasRole(currentUser, "ROLE_USER") && (
             <>
               <Route exact path="/ucsbdates/list" element={<UCSBDatesIndexPage />} />
+            </>
+          )
+        }
+        {
+          hasRole(currentUser, "ROLE_USER") && (
+            <>
+              <Route exact path="/ucsbdates/list" element={<IceCreamShopIndexPage />} />
             </>
           )
         }
@@ -54,6 +64,15 @@ function App() {
             </>
           )
         }
+        {
+          hasRole(currentUser, "ROLE_ADMIN") && (
+            <>
+              <Route exact path="/icecreamshops/edit/:id" element={<IceCreamShopEditPage />} />
+              <Route exact path="/icecreamshops/create" element={<IceCreamShopCreatePage />} />
+            </>
+          )
+        }
+        
 
       </Routes>
     </BrowserRouter>

--- a/frontend/src/fixtures/iceCreamShopFixtures.js
+++ b/frontend/src/fixtures/iceCreamShopFixtures.js
@@ -1,0 +1,38 @@
+const iceCreamShopFixtures = {
+    oneIceCreamShop:
+    [
+      {
+       "id": 1,
+        "name": "McConnell's Fine Ice Creams",
+        "description": "Longtime establishment crafting sustainable ice creams in a variety of classic & creative flavors.",
+        "flavor": "coffee"
+      }
+    ],
+
+    threeIceCreamShops:
+    [
+        {
+            "id": 2,
+             "name": "Rori’s Artisanal Creamery",
+             "description": "This is a tasty ice cream shop with special flavors in SB public market.",
+             "flavor": "mint"
+        },
+
+        {
+            "id": 3,
+             "name": "i.v. drip",
+             "description": "Quaint, compact cafe serving locally roasted coffee alongside housemade baked treats & ice cream.",
+             "flavor": "strawberry"
+        },
+
+        {
+            "id": 4,
+             "name": "Cold Stone Creamery",
+             "description": "Ice cream chain offering design-your-own creations hand-mixed on a granite slab, plus shakes & more.",
+             "flavor": "vanilla"
+        },
+        
+    ]
+};
+
+export { iceCreamShopFixtures };

--- a/frontend/src/main/components/IceCreamShops/IceCreamShopForm.js
+++ b/frontend/src/main/components/IceCreamShops/IceCreamShopForm.js
@@ -1,0 +1,111 @@
+import React from 'react'
+import { Button, Form } from 'react-bootstrap';
+import { useForm } from 'react-hook-form'
+import { useNavigate } from 'react-router-dom';
+
+function IceCreamShopForm({ initialContents, submitAction, buttonLabel = "Create" }) {
+
+    const navigate = useNavigate();
+    
+    // Stryker disable all
+    const {
+        register,
+        formState: { errors },
+        handleSubmit,
+    } = useForm(
+        { defaultValues: initialContents || {}, }
+    );
+    // Stryker enable all
+   
+    const testIdPrefix = "IceCreamShopForm";
+
+    return (
+
+        <Form onSubmit={handleSubmit(submitAction)}>
+
+            {initialContents && (
+                <Form.Group className="mb-3" >
+                    <Form.Label htmlFor="id">Id</Form.Label>
+                    <Form.Control
+                        data-testid={testIdPrefix + "-id"}
+                        id="id"
+                        type="text"
+                        {...register("id")}
+                        value={initialContents.id}
+                        disabled
+                    />
+                </Form.Group>
+            )}
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="name">Name</Form.Label>
+                <Form.Control
+                    data-testid={testIdPrefix + "-name"}
+                    id="name"
+                    type="text"
+                    isInvalid={Boolean(errors.name)}
+                    {...register("name", {
+                        required: "Name is required.",
+                        maxLength : {
+                            value: 30,
+                            message: "Max length 30 characters"
+                        }
+                    })}
+                />
+                <Form.Control.Feedback type="invalid">
+                    {errors.name?.message}
+                </Form.Control.Feedback>
+            </Form.Group>
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="description">Description</Form.Label>
+                <Form.Control
+                    data-testid={testIdPrefix + "-description"}
+                    id="description"
+                    type="text"
+                    isInvalid={Boolean(errors.description)}
+                    {...register("description", {
+                        required: "Description is required."
+                    })}
+                />
+                <Form.Control.Feedback type="invalid">
+                    {errors.description?.message}
+                </Form.Control.Feedback>
+            </Form.Group>
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="flavor">Most Popular Flavor</Form.Label>
+                <Form.Control
+                    data-testid={testIdPrefix + "-flavor"}
+                    id="flavor"
+                    type="text"
+                    isInvalid={Boolean(errors.flavor)}
+                    {...register("flavor", {
+                        required: "A popular flavor is required."
+                    })}
+                />
+                <Form.Control.Feedback type="invalid">
+                    {errors.flavor?.message}
+                </Form.Control.Feedback>
+            </Form.Group>
+
+            <Button
+                type="submit"
+                data-testid={testIdPrefix + "-submit"}
+            >
+                {buttonLabel}
+            </Button>
+            <Button
+                variant="Secondary"
+                onClick={() => navigate(-1)}
+                data-testid={testIdPrefix + "-cancel"}
+            >
+                Cancel
+            </Button>
+
+        </Form>
+
+    )
+}
+
+export default IceCreamShopForm;

--- a/frontend/src/main/components/IceCreamShops/IceCreamShopTable.js
+++ b/frontend/src/main/components/IceCreamShops/IceCreamShopTable.js
@@ -1,0 +1,68 @@
+import React from "react";
+import OurTable, { ButtonColumn } from "main/components/OurTable";
+import { useNavigate } from "react-router-dom";
+import { iceCreamShopUtils } from "main/utils/iceCreamShopUtils";
+
+const showCell = (cell) => JSON.stringify(cell.row.values);
+
+
+const defaultDeleteCallback = async (cell) => {
+    console.log(`deleteCallback: ${showCell(cell)})`);
+    iceCreamShopUtils.del(cell.row.values.id);
+}
+
+export default function IceCreamShopTable({
+    iceCreamShops,
+    deleteCallback = defaultDeleteCallback,
+    showButtons = true,
+    testIdPrefix = "IceCreamShopTable" }) {
+
+    const navigate = useNavigate();
+ 
+    const editCallback = (cell) => {
+        console.log(`editCallback: ${showCell(cell)})`);
+        navigate(`/iceCreamShops/edit/${cell.row.values.id}`)
+    }
+
+    const detailsCallback = (cell) => {
+        console.log(`detailsCallback: ${showCell(cell)})`);
+        navigate(`/iceCreamShops/details/${cell.row.values.id}`)
+    }
+
+    const columns = [
+        {
+            Header: 'id',
+            accessor: 'id', // accessor is the "key" in the data
+        },
+
+        {
+            Header: 'Name',
+            accessor: 'name',
+        },
+        {
+            Header: 'Description',
+            accessor: 'description',
+        },
+        {
+            Header: 'Most Popular Flavor',
+            accessor: 'flavor',
+        }
+    ];
+
+    const buttonColumns = [
+        ...columns,
+        ButtonColumn("Details", "primary", detailsCallback, testIdPrefix),
+        ButtonColumn("Edit", "primary", editCallback, testIdPrefix),
+        ButtonColumn("Delete", "danger", deleteCallback, testIdPrefix),
+    ]
+
+    const columnsToDisplay = showButtons ? buttonColumns : columns;
+
+    return <OurTable
+        data={iceCreamShops}
+        columns={columnsToDisplay}
+        testid={testIdPrefix}
+    />;
+};
+
+export { showCell };

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -78,6 +78,21 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
               }
             </Nav>
 
+            <Nav className="mr-auto">
+              {
+                hasRole(currentUser, "ROLE_USER") && (
+                  <NavDropdown title="IceCreamShops" id="appnavbar-icecreamshops-dropdown" data-testid="appnavbar-icecreamshops-dropdown" >
+                    <NavDropdown.Item href="/icecreamshops/list" data-testid="appnavbar-icecreamshops-list">List</NavDropdown.Item>
+                    {
+                      hasRole(currentUser, "ROLE_ADMIN") && (
+                        <NavDropdown.Item href="/icecreamshops/create" data-testid="appnavbar-icecreamshops-create">Create</NavDropdown.Item>
+                      )
+                    }
+                  </NavDropdown>
+                )
+              }
+            </Nav>
+
             <Nav className="ml-auto">
               {
                 currentUser && currentUser.loggedIn ? (

--- a/frontend/src/main/pages/IceCreamShops/IceCreamShopCreatePage.js
+++ b/frontend/src/main/pages/IceCreamShops/IceCreamShopCreatePage.js
@@ -10,7 +10,7 @@ export default function IceCreamShopCreatePage() {
   const onSubmit = async (iceCreamShop) => {
     const createdIceCreamShop = iceCreamShopUtils.add(iceCreamShop);
     console.log("createdIceCreamShop: " + JSON.stringify(createdIceCreamShop));
-    navigate("/iceCreamShops");
+    navigate("/iceCreamShops/list");
   }  
 
   return (

--- a/frontend/src/main/pages/IceCreamShops/IceCreamShopCreatePage.js
+++ b/frontend/src/main/pages/IceCreamShops/IceCreamShopCreatePage.js
@@ -1,0 +1,24 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import IceCreamShopForm from "main/components/IceCreamShops/IceCreamShopForm";
+import { useNavigate } from 'react-router-dom'
+import { iceCreamShopUtils } from 'main/utils/iceCreamShopUtils';
+
+export default function IceCreamShopCreatePage() {
+
+  let navigate = useNavigate(); 
+
+  const onSubmit = async (iceCreamShop) => {
+    const createdIceCreamShop = iceCreamShopUtils.add(iceCreamShop);
+    console.log("createdIceCreamShop: " + JSON.stringify(createdIceCreamShop));
+    navigate("/iceCreamShops");
+  }  
+
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Create New Ice Cream Shop</h1>
+        <IceCreamShopForm submitAction={onSubmit} />
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/main/pages/IceCreamShops/IceCreamShopDetailsPage.js
+++ b/frontend/src/main/pages/IceCreamShops/IceCreamShopDetailsPage.js
@@ -1,0 +1,19 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router-dom";
+import IceCreamShopTable from 'main/components/IceCreamShops/IceCreamShopTable';
+import { iceCreamShopUtils } from 'main/utils/iceCreamShopUtils';
+
+export default function IceCreamShopDetailsPage() {
+  let { id } = useParams();
+
+  const response = iceCreamShopUtils.getById(id);
+
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Ice Cream Shop Details</h1>
+        <IceCreamShopTable iceCreamShops={[response.iceCreamShop]} showButtons={false} />
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/main/pages/IceCreamShops/IceCreamShopEditPage.js
+++ b/frontend/src/main/pages/IceCreamShops/IceCreamShopEditPage.js
@@ -1,0 +1,29 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router-dom";
+import { iceCreamShopUtils }  from 'main/utils/iceCreamShopUtils';
+import IceCreamShopForm from 'main/components/IceCreamShops/IceCreamShopForm';
+import { useNavigate } from 'react-router-dom'
+
+
+export default function IceCreamShopEditPage() {
+    let { id } = useParams();
+
+    let navigate = useNavigate(); 
+
+    const response = iceCreamShopUtils.getById(id);
+
+    const onSubmit = async (iceCreamShop) => {
+        const updatedIceCreamShop = iceCreamShopUtils.update(iceCreamShop);
+        console.log("updatedIceCreamShop: " + JSON.stringify(updatedIceCreamShop));
+        navigate("/iceCreamShops");
+    }  
+
+    return (
+        <BasicLayout>
+            <div className="pt-2">
+                <h1>Edit Ice Cream Shop</h1>
+                <IceCreamShopForm submitAction={onSubmit} buttonLabel={"Update"} initialContents={response.iceCreamShop}/>
+            </div>
+        </BasicLayout>
+    )
+}

--- a/frontend/src/main/pages/IceCreamShops/IceCreamShopEditPage.js
+++ b/frontend/src/main/pages/IceCreamShops/IceCreamShopEditPage.js
@@ -15,7 +15,7 @@ export default function IceCreamShopEditPage() {
     const onSubmit = async (iceCreamShop) => {
         const updatedIceCreamShop = iceCreamShopUtils.update(iceCreamShop);
         console.log("updatedIceCreamShop: " + JSON.stringify(updatedIceCreamShop));
-        navigate("/iceCreamShops");
+        navigate("/iceCreamShops/list");
     }  
 
     return (

--- a/frontend/src/main/pages/IceCreamShops/IceCreamShopIndexPage.js
+++ b/frontend/src/main/pages/IceCreamShops/IceCreamShopIndexPage.js
@@ -1,0 +1,34 @@
+import React from 'react'
+import Button from 'react-bootstrap/Button';
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import IceCreamShopTable from 'main/components/IceCreamShops/IceCreamShopTable';
+import { iceCreamShopUtils } from 'main/utils/iceCreamShopUtils';
+import { useNavigate, Link } from 'react-router-dom';
+
+export default function IceCreamShopIndexPage() {
+
+    const navigate = useNavigate();
+
+    const iceCreamShopCollection = iceCreamShopUtils.get();
+    const iceCreamShops = iceCreamShopCollection.iceCreamShops;
+
+    const showCell = (cell) => JSON.stringify(cell.row.values);
+
+    const deleteCallback = async (cell) => {
+        console.log(`IceCreamShopIndexPage deleteCallback: ${showCell(cell)})`);
+        iceCreamShopUtils.del(cell.row.values.id);
+        navigate("/iceCreamShops");
+    }
+
+    return (
+        <BasicLayout>
+            <div className="pt-2">
+                <Button style={{ float: "right" }} as={Link} to="/iceCreamShops/create">
+                    Create Ice Cream Shop
+                </Button>
+                <h1>Ice Cream Shops</h1>
+                <IceCreamShopTable iceCreamShops={iceCreamShops} deleteCallback={deleteCallback} />
+            </div>
+        </BasicLayout>
+    )
+}

--- a/frontend/src/main/pages/IceCreamShops/IceCreamShopIndexPage.js
+++ b/frontend/src/main/pages/IceCreamShops/IceCreamShopIndexPage.js
@@ -17,7 +17,7 @@ export default function IceCreamShopIndexPage() {
     const deleteCallback = async (cell) => {
         console.log(`IceCreamShopIndexPage deleteCallback: ${showCell(cell)})`);
         iceCreamShopUtils.del(cell.row.values.id);
-        navigate("/iceCreamShops");
+        navigate("/iceCreamShops/list");
     }
 
     return (

--- a/frontend/src/main/utils/iceCreamShopUtils.js
+++ b/frontend/src/main/utils/iceCreamShopUtils.js
@@ -1,0 +1,89 @@
+// Get ice cream shops from local storage
+const get = () => {
+    const iceCreamShopValue = localStorage.getItem("iceCreamShops");
+    if (iceCreamShopValue === undefined) {
+        const iceCreamShopCollection = { nextId: 1, iceCreamShops: [] }
+        return set(iceCreamShopCollection);
+    }
+    const iceCreamShopCollection = JSON.parse(iceCreamShopValue);
+    if (iceCreamShopCollection === null) {
+        const iceCreamShopCollection = { nextId: 1, iceCreamShops: [] }
+        return set(iceCreamShopCollection);
+    }
+    return iceCreamShopCollection;
+};
+
+const getById = (id) => {
+    if (id === undefined) {
+        return { "error": "id is a required parameter" };
+    }
+    const iceCreamShopCollection = get();
+    const iceCreamShops = iceCreamShopCollection.iceCreamShops;
+
+    /* eslint-disable-next-line eqeqeq */ // we really do want == here, not ===
+    const index = iceCreamShops.findIndex((r) => r.id == id);
+    if (index === -1) {
+        return { "error": `iceCreamShop with id ${id} not found` };
+    }
+    return { iceCreamShop: iceCreamShops[index] };
+}
+
+// set iceCreamShops in local storage
+const set = (iceCreamShopCollection) => {
+    localStorage.setItem("iceCreamShops", JSON.stringify(iceCreamShopCollection));
+    return iceCreamShopCollection;
+};
+
+// add an iceCreamShop to local storage
+const add = (iceCreamShop) => {
+    const iceCreamShopCollection = get();
+    iceCreamShop = { ...iceCreamShop, id: iceCreamShopCollection.nextId };
+    iceCreamShopCollection.nextId++;
+    iceCreamShopCollection.iceCreamShops.push(iceCreamShop);
+    set(iceCreamShopCollection);
+    return iceCreamShop;
+};
+
+// update an iceCreamShop in local storage
+const update = (iceCreamShop) => {
+    const iceCreamShopCollection = get();
+
+    const iceCreamShops = iceCreamShopCollection.iceCreamShops;
+
+    /* eslint-disable-next-line eqeqeq */ // we really do want == here, not ===
+    const index = iceCreamShops.findIndex((r) => r.id == iceCreamShop.id);
+    if (index === -1) {
+        return { "error": `iceCreamShop with id ${iceCreamShop.id} not found` };
+    }
+    iceCreamShops[index] = iceCreamShop;
+    set(iceCreamShopCollection);
+    return { iceCreamShopCollection: iceCreamShopCollection };
+};
+
+// delete an iceCreamShop from local storage
+const del = (id) => {
+    if (id === undefined) {
+        return { "error": "id is a required parameter" };
+    }
+    const iceCreamShopCollection = get();
+    const iceCreamShops = iceCreamShopCollection.iceCreamShops;
+
+    /* eslint-disable-next-line eqeqeq */ // we really do want == here, not ===
+    const index = iceCreamShops.findIndex((r) => r.id == id);
+    if (index === -1) {
+        return { "error": `iceCreamShop with id ${id} not found` };
+    }
+    iceCreamShops.splice(index, 1);
+    set(iceCreamShopCollection);
+    return { iceCreamShopCollection: iceCreamShopCollection };
+};
+
+const iceCreamShopUtils = {
+    get,
+    getById,
+    add,
+    update,
+    del
+};
+
+export { iceCreamShopUtils };

--- a/frontend/src/stories/components/IceCreamShops/IceCreamShopForm.stories.js
+++ b/frontend/src/stories/components/IceCreamShops/IceCreamShopForm.stories.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import IceCreamShopForm from "main/components/IceCreamShops/IceCreamShopForm"
+import { iceCreamShopFixtures } from 'fixtures/iceCreamShopFixtures';
+
+export default {
+    title: 'components/IceCreamShops/IceCreamShopForm',
+    component: IceCreamShopForm
+};
+
+const Template = (args) => {
+    return (
+        <IceCreamShopForm {...args} />
+    )
+};
+
+export const Default = Template.bind({});
+
+Default.args = {
+    submitText: "Create",
+    submitAction: () => { console.log("Submit was clicked"); }
+};
+
+export const Show = Template.bind({});
+
+Show.args = {
+    IceCreamShop: iceCreamShopFixtures.oneIceCreamShop,
+    submitText: "",
+    submitAction: () => { }
+};

--- a/frontend/src/stories/components/IceCreamShops/IceCreamShopTable.stories.js
+++ b/frontend/src/stories/components/IceCreamShops/IceCreamShopTable.stories.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import IceCreamShopTable from 'main/components/IceCreamShops/IceCreamShopTable';
+import { iceCreamShopFixtures } from 'fixtures/iceCreamShopFixtures';
+
+export default {
+    title: 'components/iceCreamShops/IceCreamShopTable',
+    component: IceCreamShopTable
+};
+
+const Template = (args) => {
+    return (
+        <IceCreamShopTable {...args} />
+    )
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+    iceCreamShops: []
+};
+
+export const ThreeSubjectsNoButtons = Template.bind({});
+
+ThreeSubjectsNoButtons.args = {
+    iceCreamShops: iceCreamShopFixtures.threeIceCreamShops,
+    showButtons: false
+};
+
+export const ThreeSubjectsWithButtons = Template.bind({});
+ThreeSubjectsWithButtons.args = {
+    iceCreamShops: iceCreamShopFixtures.threeIceCreamShops,
+    showButtons: true
+};

--- a/frontend/src/stories/pages/IceCreamShops/IceCreamShopCreatePage.stories.js
+++ b/frontend/src/stories/pages/IceCreamShops/IceCreamShopCreatePage.stories.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import IceCreamShopCreatePage from "main/pages/IceCreamShops/IceCreamShopCreatePage";
+
+export default {
+    title: 'pages/IceCreamShops/IceCreamShopCreatePage',
+    component: IceCreamShopCreatePage
+};
+
+const Template = () => <IceCreamShopCreatePage />;
+
+export const Default = Template.bind({});

--- a/frontend/src/stories/pages/IceCreamShops/IceCreamShopDetailsPage.stories.js
+++ b/frontend/src/stories/pages/IceCreamShops/IceCreamShopDetailsPage.stories.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import IceCreamShopDetailsPage from "main/pages/IceCreamShops/IceCreamShopDetailsPage";
+
+export default {
+    title: 'pages/IceCreamShops/IceCreamShopDetailsPage',
+    component: IceCreamShopDetailsPage
+};
+
+const Template = () => <IceCreamShopDetailsPage />;
+
+export const Default = Template.bind({});

--- a/frontend/src/stories/pages/IceCreamShops/IceCreamShopEditPage.stories.js
+++ b/frontend/src/stories/pages/IceCreamShops/IceCreamShopEditPage.stories.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import IceCreamShopEditPage from "main/pages/IceCreamShops/IceCreamShopEditPage";
+
+export default {
+    title: 'pages/IceCreamShops/IceCreamShopEditPage',
+    component: IceCreamShopEditPage
+};
+
+const Template = () => <IceCreamShopEditPage />;
+
+export const Default = Template.bind({});

--- a/frontend/src/stories/pages/IceCreamShops/IceCreamShopIndexPage.stories.js
+++ b/frontend/src/stories/pages/IceCreamShops/IceCreamShopIndexPage.stories.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import IceCreamShopIndexPage from "main/pages/IceCreamShops/IceCreamShopIndexPage";
+
+export default {
+    title: 'pages/IceCreamShops/IceCreamShopIndexPage',
+    component: IceCreamShopIndexPage
+};
+
+const Template = () => <IceCreamShopIndexPage />;
+
+export const Default = Template.bind({});

--- a/frontend/src/stories/pages/UCSBDates/UCSBDatesIndexPage.stories.js
+++ b/frontend/src/stories/pages/UCSBDates/UCSBDatesIndexPage.stories.js
@@ -11,7 +11,3 @@ export default {
 const Template = () => <UCSBDatesIndexPage />;
 
 export const Default = Template.bind({});
-
-
-
-

--- a/frontend/src/tests/components/IceCreamShops/IceCreamShopForm.test.js
+++ b/frontend/src/tests/components/IceCreamShops/IceCreamShopForm.test.js
@@ -1,0 +1,77 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { BrowserRouter as Router } from "react-router-dom";
+
+import IceCreamShopForm from "main/components/IceCreamShops/IceCreamShopForm";
+import { iceCreamShopFixtures } from "fixtures/iceCreamShopFixtures";
+
+import { QueryClient, QueryClientProvider } from "react-query";
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
+
+describe("IceCreamShopForm tests", () => {
+    const queryClient = new QueryClient();
+
+    const expectedHeaders = ["Name","Description"];
+    const testId = "IceCreamShopForm";
+
+    test("renders correctly with no initialContents", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <IceCreamShopForm />
+                </Router>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByText(/Create/)).toBeInTheDocument();
+
+        expectedHeaders.forEach((headerText) => {
+            const header = screen.getByText(headerText);
+            expect(header).toBeInTheDocument();
+          });
+
+    });
+
+    test("renders correctly when passing in initialContents", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <IceCreamShopForm initialContents={iceCreamShopFixtures.oneIceCreamShop} />
+                </Router>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByText(/Create/)).toBeInTheDocument();
+
+        expectedHeaders.forEach((headerText) => {
+            const header = screen.getByText(headerText);
+            expect(header).toBeInTheDocument();
+        });
+
+        expect(await screen.findByTestId(`${testId}-id`)).toBeInTheDocument();
+        expect(screen.getByText(`Id`)).toBeInTheDocument();
+    });
+
+
+    test("that navigate(-1) is called when Cancel is clicked", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <Router>
+                    <IceCreamShopForm />
+                </Router>
+            </QueryClientProvider>
+        );
+        expect(await screen.findByTestId(`${testId}-cancel`)).toBeInTheDocument();
+        const cancelButton = screen.getByTestId(`${testId}-cancel`);
+
+        fireEvent.click(cancelButton);
+
+        await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+    });
+
+});

--- a/frontend/src/tests/components/IceCreamShops/IceCreamShopTable.test.js
+++ b/frontend/src/tests/components/IceCreamShops/IceCreamShopTable.test.js
@@ -1,0 +1,233 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "react-query";
+import IceCreamShopTable, { showCell } from "main/components/IceCreamShops/IceCreamShopTable";
+import { iceCreamShopFixtures } from "fixtures/iceCreamShopFixtures";
+import mockConsole from "jest-mock-console";
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockedNavigate
+}));
+
+describe("IceCreamShopTable tests", () => {
+  const queryClient = new QueryClient();
+
+  const expectedHeaders = ["id", "Name", "Description", "Most Popular Flavor"];
+  const expectedFields = ["id", "name", "description", 'flavor'];
+  const testId = "IceCreamShopTable";
+
+  test("showCell function works properly", () => {
+    const cell = {
+      row: {
+        values: { a: 1, b: 2, c: 3 }
+      },
+    };
+    expect(showCell(cell)).toBe(`{"a":1,"b":2,"c":3}`);
+  });
+
+  test("renders without crashing for empty table", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <IceCreamShopTable iceCreamShops={[]} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+  });
+
+
+
+  test("Has the expected column headers, content and buttons", () => {
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <IceCreamShopTable iceCreamShops={iceCreamShopFixtures.threeIceCreamShops} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("2");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-name`)).toHaveTextContent("Rori’s Artisanal Creamery");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-description`)).toHaveTextContent("This is a tasty ice cream shop with special flavors in SB public market.");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-flavor`)).toHaveTextContent("mint");
+
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("3");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-name`)).toHaveTextContent("i.v. drip");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-description`)).toHaveTextContent("Quaint, compact cafe serving locally roasted coffee alongside housemade baked treats & ice cream.");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-flavor`)).toHaveTextContent("strawberry");
+
+    expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("4");
+    expect(screen.getByTestId(`${testId}-cell-row-2-col-name`)).toHaveTextContent("Cold Stone Creamery");
+    expect(screen.getByTestId(`${testId}-cell-row-2-col-description`)).toHaveTextContent("Ice cream chain offering design-your-own creations hand-mixed on a granite slab, plus shakes & more.");
+    expect(screen.getByTestId(`${testId}-cell-row-2-col-flavor`)).toHaveTextContent("vanilla");
+
+    const detailsButton = screen.getByTestId(`${testId}-cell-row-0-col-Details-button`);
+    expect(detailsButton).toBeInTheDocument();
+    expect(detailsButton).toHaveClass("btn-primary");
+
+    const editButton = screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`);
+    expect(editButton).toBeInTheDocument();
+    expect(editButton).toHaveClass("btn-primary");
+
+    const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+    expect(deleteButton).toBeInTheDocument();
+    expect(deleteButton).toHaveClass("btn-danger");
+
+  });
+
+  test("Has the expected column headers, content and no buttons when showButtons=false", () => {
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <IceCreamShopTable iceCreamShops={iceCreamShopFixtures.threeIceCreamShops} showButtons={false} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("2");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-name`)).toHaveTextContent("Rori’s Artisanal Creamery");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-description`)).toHaveTextContent("This is a tasty ice cream shop with special flavors in SB public market.");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-flavor`)).toHaveTextContent("mint");
+
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("3");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-name`)).toHaveTextContent("i.v. drip");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-description`)).toHaveTextContent("Quaint, compact cafe serving locally roasted coffee alongside housemade baked treats & ice cream.");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-flavor`)).toHaveTextContent("strawberry");
+
+    expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("4");
+    expect(screen.getByTestId(`${testId}-cell-row-2-col-name`)).toHaveTextContent("Cold Stone Creamery");
+    expect(screen.getByTestId(`${testId}-cell-row-2-col-description`)).toHaveTextContent("Ice cream chain offering design-your-own creations hand-mixed on a granite slab, plus shakes & more.");
+    expect(screen.getByTestId(`${testId}-cell-row-2-col-flavor`)).toHaveTextContent("vanilla");
+
+    expect(screen.queryByText("Delete")).not.toBeInTheDocument();
+    expect(screen.queryByText("Edit")).not.toBeInTheDocument();
+    expect(screen.queryByText("Details")).not.toBeInTheDocument();
+  });
+
+
+  test("Edit button navigates to the edit page", async () => {
+    // arrange
+    const restoreConsole = mockConsole();
+
+    // act - render the component
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <IceCreamShopTable iceCreamShops={iceCreamShopFixtures.threeIceCreamShops} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // assert - check that the expected content is rendered
+    expect(await screen.findByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("2");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-name`)).toHaveTextContent("Rori’s Artisanal Creamery");
+
+    const editButton = screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`);
+    expect(editButton).toBeInTheDocument();
+
+    // act - click the edit button
+    fireEvent.click(editButton);
+
+    // assert - check that the navigate function was called with the expected path
+    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/iceCreamShops/edit/2'));
+
+    // assert - check that the console.log was called with the expected message
+    expect(console.log).toHaveBeenCalled();
+    const message = console.log.mock.calls[0][0];
+    const expectedMessage = `editCallback: {"id":2,"name":"Rori’s Artisanal Creamery","description":"This is a tasty ice cream shop with special flavors in SB public market.","flavor":"mint"})`;
+    expect(message).toMatch(expectedMessage);
+    restoreConsole();
+  });
+
+  test("Details button navigates to the details page", async () => {
+    // arrange
+    const restoreConsole = mockConsole();
+
+    // act - render the component
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <IceCreamShopTable iceCreamShops={iceCreamShopFixtures.threeIceCreamShops} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // assert - check that the expected content is rendered
+    expect(await screen.findByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("2");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-name`)).toHaveTextContent("Rori’s Artisanal Creamery");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-description`)).toHaveTextContent("This is a tasty ice cream shop with special flavors in SB public market.");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-flavor`)).toHaveTextContent("mint");
+
+    const detailsButton = screen.getByTestId(`${testId}-cell-row-0-col-Details-button`);
+    expect(detailsButton).toBeInTheDocument();
+
+    // act - click the details button
+    fireEvent.click(detailsButton);
+
+    // assert - check that the navigate function was called with the expected path
+    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/iceCreamShops/details/2'));
+
+    // assert - check that the console.log was called with the expected message
+    expect(console.log).toHaveBeenCalled();
+    const message = console.log.mock.calls[0][0];
+    const expectedMessage = `detailsCallback: {"id":2,"name":"Rori’s Artisanal Creamery","description":"This is a tasty ice cream shop with special flavors in SB public market.","flavor":"mint"})`;
+    expect(message).toMatch(expectedMessage);
+    restoreConsole();
+  });
+
+  test("Delete button calls delete callback", async () => {
+    // arrange
+    const restoreConsole = mockConsole();
+
+    // act - render the component
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <IceCreamShopTable iceCreamShops={iceCreamShopFixtures.threeIceCreamShops} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // assert - check that the expected content is rendered
+    expect(await screen.findByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("2");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-name`)).toHaveTextContent("Rori’s Artisanal Creamery");
+
+    const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+    expect(deleteButton).toBeInTheDocument();
+
+     // act - click the delete button
+    fireEvent.click(deleteButton);
+
+     // assert - check that the console.log was called with the expected message
+     await(waitFor(() => expect(console.log).toHaveBeenCalled()));
+     const message = console.log.mock.calls[0][0];
+     const expectedMessage = `deleteCallback: {"id":2,"name":"Rori’s Artisanal Creamery","description":"This is a tasty ice cream shop with special flavors in SB public market.","flavor":"mint"})`;
+     expect(message).toMatch(expectedMessage);
+     restoreConsole();
+  });
+});

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -212,6 +212,54 @@ describe("AppNavbar tests", () => {
         await findByTestId(/appnavbar-ucsbdates-create/);
 
     });
+
+    test("renders the icecreamshops menu correctly for a user", async () => {
+
+        const currentUser = currentUserFixtures.userOnly;
+        const systemInfo = systemInfoFixtures.showingBoth;
+
+        const doLogin = jest.fn();
+
+        const {getByTestId, findByTestId  } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AppNavbar currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await findByTestId("appnavbar-icecreamshops-dropdown");
+        const dropdown = getByTestId("appnavbar-icecreamshops-dropdown");
+        const aElement = dropdown.querySelector("a");
+        expect(aElement).toBeInTheDocument();
+        aElement?.click();
+        await findByTestId("appnavbar-icecreamshops-list");
+
+    });
+
+    test("renders the icecreamshops menu correctly for an admin", async () => {
+
+        const currentUser = currentUserFixtures.adminUser;
+        const systemInfo = systemInfoFixtures.showingBoth;
+
+        const doLogin = jest.fn();
+
+        const {getByTestId, findByTestId  } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AppNavbar currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await findByTestId("appnavbar-icecreamshops-dropdown");
+        const dropdown = getByTestId("appnavbar-icecreamshops-dropdown");
+        const aElement = dropdown.querySelector("a");
+        expect(aElement).toBeInTheDocument();
+        aElement?.click();
+        await findByTestId(/appnavbar-icecreamshops-create/);
+
+    });
 });
 
 

--- a/frontend/src/tests/pages/IceCreamShops/IceCreamShopCreatePage.test.js
+++ b/frontend/src/tests/pages/IceCreamShops/IceCreamShopCreatePage.test.js
@@ -33,7 +33,7 @@ describe("IceCreamShopCreatePage tests", () => {
         );
     });
 
-    test("redirects to /iceCreamShops on submit", async () => {
+    test("redirects to /iceCreamShops/list on submit", async () => {
 
         const restoreConsole = mockConsole();
 
@@ -76,7 +76,7 @@ describe("IceCreamShopCreatePage tests", () => {
         });
 
         await waitFor(() => expect(mockAdd).toHaveBeenCalled());
-        await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith("/iceCreamShops"));
+        await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith("/iceCreamShops/list"));
 
         // assert - check that the console.log was called with the expected message
         expect(console.log).toHaveBeenCalled();

--- a/frontend/src/tests/pages/IceCreamShops/IceCreamShopCreatePage.test.js
+++ b/frontend/src/tests/pages/IceCreamShops/IceCreamShopCreatePage.test.js
@@ -1,0 +1,92 @@
+import { render, screen, fireEvent, act, waitFor } from "@testing-library/react";
+import IceCreamShopCreatePage from "main/pages/IceCreamShops/IceCreamShopCreatePage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import mockConsole from "jest-mock-console";
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockNavigate
+}));
+
+const mockAdd = jest.fn();
+jest.mock('main/utils/iceCreamShopUtils', () => {
+    return {
+        __esModule: true,
+        iceCreamShopUtils: {
+            add: () => { return mockAdd(); }
+        }
+    }
+});
+
+describe("IceCreamShopCreatePage tests", () => {
+
+    const queryClient = new QueryClient();
+    test("renders without crashing", () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <IceCreamShopCreatePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    });
+
+    test("redirects to /iceCreamShops on submit", async () => {
+
+        const restoreConsole = mockConsole();
+
+        mockAdd.mockReturnValue({
+            "iceCreamShop": {
+                id: 3,
+                name: "Baskin Robbins",
+                description: "A lot of ice cream",
+                flavor: "Vanilla"
+            }
+        });
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <IceCreamShopCreatePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        )
+
+        const nameInput = screen.getByLabelText("Name");
+        expect(nameInput).toBeInTheDocument();
+
+
+        const descriptionInput = screen.getByLabelText("Description");
+        expect(descriptionInput).toBeInTheDocument();
+
+        const flavorInput = screen.getByLabelText("Most Popular Flavor");
+        expect(flavorInput).toBeInTheDocument();
+
+        const createButton = screen.getByText("Create");
+        expect(createButton).toBeInTheDocument();
+
+        await act(async () => {
+            fireEvent.change(nameInput, { target: { value: 'Baskin Robbins' } })
+            fireEvent.change(descriptionInput, { target: { value: 'A lot of ice cream' } })
+            fireEvent.change(flavorInput, { target: { value: 'Vanilla' } })
+
+            fireEvent.click(createButton);
+        });
+
+        await waitFor(() => expect(mockAdd).toHaveBeenCalled());
+        await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith("/iceCreamShops"));
+
+        // assert - check that the console.log was called with the expected message
+        expect(console.log).toHaveBeenCalled();
+        const message = console.log.mock.calls[0][0];
+        const expectedMessage =  `createdIceCreamShop: {"iceCreamShop":{"id":3,"name":"Baskin Robbins","description":"A lot of ice cream","flavor":"Vanilla"}`
+
+        expect(message).toMatch(expectedMessage);
+        restoreConsole();
+
+    });
+
+});
+

--- a/frontend/src/tests/pages/IceCreamShops/IceCreamShopCreatePage.test.js
+++ b/frontend/src/tests/pages/IceCreamShops/IceCreamShopCreatePage.test.js
@@ -3,6 +3,10 @@ import IceCreamShopCreatePage from "main/pages/IceCreamShops/IceCreamShopCreateP
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import mockConsole from "jest-mock-console";
+import { apiCurrentUserFixtures }  from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
 
 const mockNavigate = jest.fn();
 jest.mock('react-router-dom', () => ({
@@ -21,6 +25,10 @@ jest.mock('main/utils/iceCreamShopUtils', () => {
 });
 
 describe("IceCreamShopCreatePage tests", () => {
+
+    const axiosMock =new AxiosMockAdapter(axios);
+    axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither); 
 
     const queryClient = new QueryClient();
     test("renders without crashing", () => {

--- a/frontend/src/tests/pages/IceCreamShops/IceCreamShopDetailsPage.test.js
+++ b/frontend/src/tests/pages/IceCreamShops/IceCreamShopDetailsPage.test.js
@@ -2,6 +2,10 @@ import { render, screen } from "@testing-library/react";
 import IceCreamShopDetailsPage from "main/pages/IceCreamShops/IceCreamShopDetailsPage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
+import { apiCurrentUserFixtures }  from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
 
 const mockNavigate = jest.fn();
 jest.mock('react-router-dom', () => ({
@@ -31,6 +35,10 @@ jest.mock('main/utils/iceCreamShopUtils', () => {
 });
 
 describe("IceCreamShopDetailsPage tests", () => {
+
+    const axiosMock =new AxiosMockAdapter(axios);
+    axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither); 
 
     const queryClient = new QueryClient();
     test("renders without crashing", () => {

--- a/frontend/src/tests/pages/IceCreamShops/IceCreamShopDetailsPage.test.js
+++ b/frontend/src/tests/pages/IceCreamShops/IceCreamShopDetailsPage.test.js
@@ -1,0 +1,64 @@
+import { render, screen } from "@testing-library/react";
+import IceCreamShopDetailsPage from "main/pages/IceCreamShops/IceCreamShopDetailsPage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useParams: () => ({
+        id: 3
+    }),
+    useNavigate: () => mockNavigate
+}));
+
+jest.mock('main/utils/iceCreamShopUtils', () => {
+    return {
+        __esModule: true,
+        iceCreamShopUtils: {
+            getById: (_id) => {
+                return {
+                    iceCreamShop: {
+                        id: 3,
+                        name: "i.v. drip",
+                        description: "Quaint, compact cafe serving locally roasted coffee alongside housemade baked treats & ice cream.",
+                        flavor: "strawberry"
+                    }
+                }
+            }
+        }
+    }
+});
+
+describe("IceCreamShopDetailsPage tests", () => {
+
+    const queryClient = new QueryClient();
+    test("renders without crashing", () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <IceCreamShopDetailsPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    });
+
+    test("loads the correct fields, and no buttons", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <IceCreamShopDetailsPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+        expect(screen.getByText("i.v. drip")).toBeInTheDocument();
+        expect(screen.getByText("Quaint, compact cafe serving locally roasted coffee alongside housemade baked treats & ice cream.")).toBeInTheDocument();
+        expect(screen.getByText("strawberry")).toBeInTheDocument();
+
+        expect(screen.queryByText("Delete")).not.toBeInTheDocument();
+        expect(screen.queryByText("Edit")).not.toBeInTheDocument();
+        expect(screen.queryByText("Details")).not.toBeInTheDocument();
+    });
+
+});
+

--- a/frontend/src/tests/pages/IceCreamShops/IceCreamShopEditPage.test.js
+++ b/frontend/src/tests/pages/IceCreamShops/IceCreamShopEditPage.test.js
@@ -107,7 +107,7 @@ describe("IceCreamShopEditPage tests", () => {
         });
 
         await waitFor(() => expect(mockUpdate).toHaveBeenCalled());
-        await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith("/iceCreamShops"));
+        await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith("/iceCreamShops/list"));
 
         // assert - check that the console.log was called with the expected message
         expect(console.log).toHaveBeenCalled();

--- a/frontend/src/tests/pages/IceCreamShops/IceCreamShopEditPage.test.js
+++ b/frontend/src/tests/pages/IceCreamShops/IceCreamShopEditPage.test.js
@@ -1,0 +1,123 @@
+import { render, screen, act, waitFor, fireEvent } from "@testing-library/react";
+import IceCreamShopEditPage from "main/pages/IceCreamShops/IceCreamShopEditPage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import mockConsole from "jest-mock-console";
+
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useParams: () => ({
+        id: 3
+    }),
+    useNavigate: () => mockNavigate
+}));
+
+const mockUpdate = jest.fn();
+jest.mock('main/utils/iceCreamShopUtils', () => {
+    return {
+        __esModule: true,
+        iceCreamShopUtils: {
+            update: (_iceCreamShop) => {return mockUpdate();},
+            getById: (_id) => {
+                return {
+                    iceCreamShop: {
+                        id: 3,
+                        name: "Freebirds",
+                        description: "Burritos",
+                        flavor: "Carne Asada"
+                    }
+                }
+            }
+        }
+    }
+});
+
+
+describe("IceCreamShopEditPage tests", () => {
+
+    const queryClient = new QueryClient();
+
+    test("renders without crashing", () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <IceCreamShopEditPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    });
+
+    test("loads the correct fields", async () => {
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <IceCreamShopEditPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        expect(screen.getByTestId("IceCreamShopForm-name")).toBeInTheDocument();
+        expect(screen.getByDisplayValue('Freebirds')).toBeInTheDocument();
+        expect(screen.getByDisplayValue('Burritos')).toBeInTheDocument();
+        expect(screen.getByDisplayValue('Carne Asada')).toBeInTheDocument();
+    });
+
+    test("redirects to /iceCreamShops on submit", async () => {
+
+        const restoreConsole = mockConsole();
+
+        mockUpdate.mockReturnValue({
+            "iceCreamShop": {
+                id: 3,
+                name: "Baskin Robbins",
+                description: "A lot of ice cream",
+                flavor: "Strawberry"
+            }
+        });
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <IceCreamShopEditPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        )
+
+        const nameInput = screen.getByLabelText("Name");
+        expect(nameInput).toBeInTheDocument();
+
+
+        const descriptionInput = screen.getByLabelText("Description");
+        expect(descriptionInput).toBeInTheDocument();
+
+        const flavorInput = screen.getByLabelText("Most Popular Flavor");
+        expect(flavorInput).toBeInTheDocument();
+
+        const updateButton = screen.getByText("Update");
+        expect(updateButton).toBeInTheDocument();
+
+        await act(async () => {
+            fireEvent.change(nameInput, { target: { value: 'Baskin Robbins' } })
+            fireEvent.change(descriptionInput, { target: { value: 'A lot of ice cream' } })
+            fireEvent.change(flavorInput, { target: { value: 'Strawberry' } })
+            fireEvent.click(updateButton);
+        });
+
+        await waitFor(() => expect(mockUpdate).toHaveBeenCalled());
+        await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith("/iceCreamShops"));
+
+        // assert - check that the console.log was called with the expected message
+        expect(console.log).toHaveBeenCalled();
+        const message = console.log.mock.calls[0][0];
+        const expectedMessage =  `updatedIceCreamShop: {"iceCreamShop":{"id":3,"name":"Baskin Robbins","description":"A lot of ice cream","flavor":"Strawberry"}`
+
+        expect(message).toMatch(expectedMessage);
+        restoreConsole();
+
+    });
+
+});
+

--- a/frontend/src/tests/pages/IceCreamShops/IceCreamShopEditPage.test.js
+++ b/frontend/src/tests/pages/IceCreamShops/IceCreamShopEditPage.test.js
@@ -3,6 +3,10 @@ import IceCreamShopEditPage from "main/pages/IceCreamShops/IceCreamShopEditPage"
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import mockConsole from "jest-mock-console";
+import { apiCurrentUserFixtures }  from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
 
 const mockNavigate = jest.fn();
 
@@ -36,6 +40,10 @@ jest.mock('main/utils/iceCreamShopUtils', () => {
 
 
 describe("IceCreamShopEditPage tests", () => {
+
+    const axiosMock =new AxiosMockAdapter(axios);
+    axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither); 
 
     const queryClient = new QueryClient();
 

--- a/frontend/src/tests/pages/IceCreamShops/IceCreamShopIndexPage.test.js
+++ b/frontend/src/tests/pages/IceCreamShops/IceCreamShopIndexPage.test.js
@@ -105,7 +105,7 @@ describe("IceCreamShopIndexPage tests", () => {
         expect(mockDelete).toHaveBeenCalledTimes(1);
         expect(mockDelete).toHaveBeenCalledWith(3);
 
-        await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith("/iceCreamShops"));
+        await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith("/iceCreamShops/list"));
 
 
         // assert - check that the console.log was called with the expected message

--- a/frontend/src/tests/pages/IceCreamShops/IceCreamShopIndexPage.test.js
+++ b/frontend/src/tests/pages/IceCreamShops/IceCreamShopIndexPage.test.js
@@ -3,6 +3,10 @@ import IceCreamShopIndexPage from "main/pages/IceCreamShops/IceCreamShopIndexPag
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import mockConsole from "jest-mock-console";
+import { apiCurrentUserFixtures }  from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
 
 const mockNavigate = jest.fn();
 jest.mock('react-router-dom', () => ({
@@ -37,6 +41,10 @@ jest.mock('main/utils/iceCreamShopUtils', () => {
 
 
 describe("IceCreamShopIndexPage tests", () => {
+
+    const axiosMock =new AxiosMockAdapter(axios);
+    axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither); 
 
     const queryClient = new QueryClient();
     test("renders without crashing", () => {

--- a/frontend/src/tests/pages/IceCreamShops/IceCreamShopIndexPage.test.js
+++ b/frontend/src/tests/pages/IceCreamShops/IceCreamShopIndexPage.test.js
@@ -1,0 +1,122 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import IceCreamShopIndexPage from "main/pages/IceCreamShops/IceCreamShopIndexPage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import mockConsole from "jest-mock-console";
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockNavigate
+}));
+
+const mockDelete = jest.fn();
+jest.mock('main/utils/iceCreamShopUtils', () => {
+    return {
+        __esModule: true,
+        iceCreamShopUtils: {
+            del: (id) => {
+                return mockDelete(id);
+            },
+            get: () => {
+                return {
+                    nextId: 5,
+                    iceCreamShops: [
+                        {
+                            "id": 3,
+                            "name": "i.v. drip",
+                            "description": "Quaint, compact cafe serving locally roasted coffee alongside housemade baked treats & ice cream.",
+                            "flavor": "strawberry"
+                        },
+                    ]
+                }
+            }
+        }
+    }
+});
+
+
+describe("IceCreamShopIndexPage tests", () => {
+
+    const queryClient = new QueryClient();
+    test("renders without crashing", () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <IceCreamShopIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    });
+
+    test("renders correct fields", () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <IceCreamShopIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        const createIceCreamShopButton = screen.getByText("Create Ice Cream Shop");
+        expect(createIceCreamShopButton).toBeInTheDocument();
+        expect(createIceCreamShopButton).toHaveAttribute("style", "float: right;");
+
+        const name = screen.getByText("i.v. drip");
+        expect(name).toBeInTheDocument();
+
+        const description = screen.getByText("Quaint, compact cafe serving locally roasted coffee alongside housemade baked treats & ice cream.");
+        expect(description).toBeInTheDocument();
+
+        const flavor = screen.getByText("strawberry");
+        expect(flavor).toBeInTheDocument();
+
+        expect(screen.getByTestId("IceCreamShopTable-cell-row-0-col-Delete-button")).toBeInTheDocument();
+        expect(screen.getByTestId("IceCreamShopTable-cell-row-0-col-Details-button")).toBeInTheDocument();
+        expect(screen.getByTestId("IceCreamShopTable-cell-row-0-col-Edit-button")).toBeInTheDocument();
+    });
+
+    test("delete button calls delete and reloads page", async () => {
+
+        const restoreConsole = mockConsole();
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <IceCreamShopIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        const name = screen.getByText("i.v. drip");
+        expect(name).toBeInTheDocument();
+
+        const description = screen.getByText("Quaint, compact cafe serving locally roasted coffee alongside housemade baked treats & ice cream.");
+        expect(description).toBeInTheDocument();
+
+        const flavor = screen.getByText("strawberry");
+        expect(flavor).toBeInTheDocument();
+
+        const deleteButton = screen.getByTestId("IceCreamShopTable-cell-row-0-col-Delete-button");
+        expect(deleteButton).toBeInTheDocument();
+
+        deleteButton.click();
+
+        expect(mockDelete).toHaveBeenCalledTimes(1);
+        expect(mockDelete).toHaveBeenCalledWith(3);
+
+        await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith("/iceCreamShops"));
+
+
+        // assert - check that the console.log was called with the expected message
+        expect(console.log).toHaveBeenCalled();
+        const message = console.log.mock.calls[0][0];
+        const expectedMessage = `IceCreamShopIndexPage deleteCallback: {"id":3,"name":"i.v. drip","description":"Quaint, compact cafe serving locally roasted coffee alongside housemade baked treats & ice cream.","flavor":"strawberry"}`;
+        expect(message).toMatch(expectedMessage);
+        restoreConsole();
+
+    });
+
+});
+
+

--- a/frontend/src/tests/utils/iceCreamShopUtils.test.js
+++ b/frontend/src/tests/utils/iceCreamShopUtils.test.js
@@ -1,0 +1,289 @@
+import { iceCreamShopFixtures } from "fixtures/iceCreamShopFixtures";
+import { iceCreamShopUtils } from "main/utils/iceCreamShopUtils";
+
+describe("iceCreamShopUtils tests", () => {
+    // return a function that can be used as a mock implementation of getItem
+    // the value passed in will be convertd to JSON and returned as the value
+    // for the key "iceCreamShops".  Any other key results in an error
+    const createGetItemMock = (returnValue) => (key) => {
+        if (key === "iceCreamShops") {
+            return JSON.stringify(returnValue);
+        } else {
+            throw new Error("Unexpected key: " + key);
+        }
+    };
+
+    describe("get", () => {
+
+        test("When iceCreamShops is undefined in local storage, should set to empty list", () => {
+
+            // arrange
+            const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
+            getItemSpy.mockImplementation(createGetItemMock(undefined));
+
+            const setItemSpy = jest.spyOn(Storage.prototype, 'setItem');
+            setItemSpy.mockImplementation((_key, _value) => null);
+
+            // act
+            const result = iceCreamShopUtils.get();
+
+            // assert
+            const expected = { nextId: 1, iceCreamShops: [] } ;
+            expect(result).toEqual(expected);
+
+            const expectedJSON = JSON.stringify(expected);
+            expect(setItemSpy).toHaveBeenCalledWith("iceCreamShops", expectedJSON);
+        });
+
+        test("When iceCreamShops is null in local storage, should set to empty list", () => {
+
+            // arrange
+            const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
+            getItemSpy.mockImplementation(createGetItemMock(null));
+
+            const setItemSpy = jest.spyOn(Storage.prototype, 'setItem');
+            setItemSpy.mockImplementation((_key, _value) => null);
+
+            // act
+            const result = iceCreamShopUtils.get();
+
+            // assert
+            const expected = { nextId: 1, iceCreamShops: [] } ;
+            expect(result).toEqual(expected);
+
+            const expectedJSON = JSON.stringify(expected);
+            expect(setItemSpy).toHaveBeenCalledWith("iceCreamShops", expectedJSON);
+        });
+
+        test("When iceCreamShops is [] in local storage, should return []", () => {
+
+            // arrange
+            const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
+            getItemSpy.mockImplementation(createGetItemMock({ nextId: 1, iceCreamShops: [] }));
+
+            const setItemSpy = jest.spyOn(Storage.prototype, 'setItem');
+            setItemSpy.mockImplementation((_key, _value) => null);
+
+            // act
+            const result = iceCreamShopUtils.get();
+
+            // assert
+            const expected = { nextId: 1, iceCreamShops: [] };
+            expect(result).toEqual(expected);
+
+            expect(setItemSpy).not.toHaveBeenCalled();
+        });
+
+        test("When iceCreamShops is JSON of three iceCreamShops, should return that JSON", () => {
+
+            // arrange
+            const threeIceCreamShops = iceCreamShopFixtures.threeIceCreamShops;
+            const mockIceCreamShopCollection = { nextId: 10, iceCreamShops: threeIceCreamShops };
+
+            const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
+            getItemSpy.mockImplementation(createGetItemMock(mockIceCreamShopCollection));
+
+            const setItemSpy = jest.spyOn(Storage.prototype, 'setItem');
+            setItemSpy.mockImplementation((_key, _value) => null);
+
+            // act
+            const result = iceCreamShopUtils.get();
+
+            // assert
+            expect(result).toEqual(mockIceCreamShopCollection);
+            expect(setItemSpy).not.toHaveBeenCalled();
+        });
+    });
+
+
+    describe("getById", () => {
+        test("Check that getting an iceCreamShop by id works", () => {
+
+            // arrange
+            const threeIceCreamShops = iceCreamShopFixtures.threeIceCreamShops;
+            const idToGet = threeIceCreamShops[1].id;
+
+            const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
+            getItemSpy.mockImplementation(createGetItemMock({ nextId: 5, iceCreamShops: threeIceCreamShops }));
+
+            // act
+            const result = iceCreamShopUtils.getById(idToGet);
+
+            // assert
+
+            const expected = { iceCreamShop: threeIceCreamShops[1] };
+            expect(result).toEqual(expected);
+        });
+
+        test("Check that getting a non-existing iceCreamShop returns an error", () => {
+
+            // arrange
+            const threeIceCreamShops = iceCreamShopFixtures.threeIceCreamShops;
+
+            const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
+            getItemSpy.mockImplementation(createGetItemMock({ nextId: 5, iceCreamShops: threeIceCreamShops }));
+
+            // act
+            const result = iceCreamShopUtils.getById(99);
+
+            // assert
+            const expectedError = `iceCreamShop with id 99 not found`
+            expect(result).toEqual({ error: expectedError });
+        });
+
+        test("Check that an error is returned when id not passed", () => {
+
+            // arrange
+            const threeIceCreamShops = iceCreamShopFixtures.threeIceCreamShops;
+
+            const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
+            getItemSpy.mockImplementation(createGetItemMock({ nextId: 5, iceCreamShops: threeIceCreamShops }));
+
+            // act
+            const result = iceCreamShopUtils.getById();
+
+            // assert
+            const expectedError = `id is a required parameter`
+            expect(result).toEqual({ error: expectedError });
+        });
+
+    });
+    describe("add", () => {
+        test("Starting from [], check that adding one iceCreamShop works", () => {
+
+            // arrange
+            const iceCreamShop = iceCreamShopFixtures.oneIceCreamShop[0];
+            const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
+            getItemSpy.mockImplementation(createGetItemMock({ nextId: 1, iceCreamShops: [] }));
+
+            const setItemSpy = jest.spyOn(Storage.prototype, 'setItem');
+            setItemSpy.mockImplementation((_key, _value) => null);
+
+            // act
+            const result = iceCreamShopUtils.add(iceCreamShop);
+
+            // assert
+            expect(result).toEqual(iceCreamShop);
+            expect(setItemSpy).toHaveBeenCalledWith("iceCreamShops",
+                JSON.stringify({ nextId: 2, iceCreamShops: iceCreamShopFixtures.oneIceCreamShop }));
+        });
+    });
+
+    describe("update", () => {
+        test("Check that updating an existing iceCreamShop works", () => {
+
+            // arrange
+            const threeIceCreamShops = iceCreamShopFixtures.threeIceCreamShops;
+            const updatedIceCreamShop = {
+                ...threeIceCreamShops[0],
+                name: "Updated Name"
+            };
+            const threeIceCreamShopsUpdated = [
+                updatedIceCreamShop,
+                threeIceCreamShops[1],
+                threeIceCreamShops[2]
+            ];
+
+            const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
+            getItemSpy.mockImplementation(createGetItemMock({ nextId: 5, iceCreamShops: threeIceCreamShops }));
+
+            const setItemSpy = jest.spyOn(Storage.prototype, 'setItem');
+            setItemSpy.mockImplementation((_key, _value) => null);
+
+            // act
+            const result = iceCreamShopUtils.update(updatedIceCreamShop);
+
+            // assert
+            const expected = { iceCreamShopCollection: { nextId: 5, iceCreamShops: threeIceCreamShopsUpdated } };
+            expect(result).toEqual(expected);
+            expect(setItemSpy).toHaveBeenCalledWith("iceCreamShops", JSON.stringify(expected.iceCreamShopCollection));
+        });
+        test("Check that updating an non-existing iceCreamShop returns an error", () => {
+
+            // arrange
+            const threeIceCreamShops = iceCreamShopFixtures.threeIceCreamShops;
+
+            const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
+            getItemSpy.mockImplementation(createGetItemMock({ nextId: 5, iceCreamShops: threeIceCreamShops }));
+
+            const setItemSpy = jest.spyOn(Storage.prototype, 'setItem');
+            setItemSpy.mockImplementation((_key, _value) => null);
+
+            const updatedIceCreamShop = {
+                id: 99,
+                name: "Fake Name",
+                description: "Fake Description"
+            }
+
+            // act
+            const result = iceCreamShopUtils.update(updatedIceCreamShop);
+
+            // assert
+            const expectedError = `iceCreamShop with id 99 not found`
+            expect(result).toEqual({ error: expectedError });
+            expect(setItemSpy).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("del", () => {
+        test("Check that deleting an iceCreamShop by id works", () => {
+
+            // arrange
+            const threeIceCreamShops = iceCreamShopFixtures.threeIceCreamShops;
+            const idToDelete = threeIceCreamShops[1].id;
+            const threeIceCreamShopsUpdated = [
+                threeIceCreamShops[0],
+                threeIceCreamShops[2]
+            ];
+
+            const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
+            getItemSpy.mockImplementation(createGetItemMock({ nextId: 5, iceCreamShops: threeIceCreamShops }));
+
+            const setItemSpy = jest.spyOn(Storage.prototype, 'setItem');
+            setItemSpy.mockImplementation((_key, _value) => null);
+
+            // act
+            const result = iceCreamShopUtils.del(idToDelete);
+
+            // assert
+
+            const expected = { iceCreamShopCollection: { nextId: 5, iceCreamShops: threeIceCreamShopsUpdated } };
+            expect(result).toEqual(expected);
+            expect(setItemSpy).toHaveBeenCalledWith("iceCreamShops", JSON.stringify(expected.iceCreamShopCollection));
+        });
+        test("Check that deleting a non-existing iceCreamShop returns an error", () => {
+
+            // arrange
+            const threeIceCreamShops = iceCreamShopFixtures.threeIceCreamShops;
+
+            const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
+            getItemSpy.mockImplementation(createGetItemMock({ nextId: 5, iceCreamShops: threeIceCreamShops }));
+
+            const setItemSpy = jest.spyOn(Storage.prototype, 'setItem');
+            setItemSpy.mockImplementation((_key, _value) => null);
+
+            // act
+            const result = iceCreamShopUtils.del(99);
+
+            // assert
+            const expectedError = `iceCreamShop with id 99 not found`
+            expect(result).toEqual({ error: expectedError });
+            expect(setItemSpy).not.toHaveBeenCalled();
+        });
+        test("Check that an error is returned when id not passed", () => {
+
+            // arrange
+            const threeIceCreamShops = iceCreamShopFixtures.threeIceCreamShops;
+
+            const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
+            getItemSpy.mockImplementation(createGetItemMock({ nextId: 5, iceCreamShops: threeIceCreamShops }));
+
+            // act
+            const result = iceCreamShopUtils.del();
+
+            // assert
+            const expectedError = `id is a required parameter`
+            expect(result).toEqual({ error: expectedError });
+        });
+    });
+});


### PR DESCRIPTION
In this PR, I moved over the iceCreamShop frontend from team01. This also, like books, includes the addition of the stories files for the pages and the changing of redirects of the index page iceCreamShops/list.

Similar to the other frontend PRs, this also does **not** include the details page for iceCreamShop and is only being opened in order to prevent the database connection issues from being blocked.